### PR TITLE
Adding local seed values

### DIFF
--- a/fibonacci/fibonacci.go
+++ b/fibonacci/fibonacci.go
@@ -7,25 +7,24 @@ import (
 
 var (
 	iter *int = flag.Int("iter", 12, "length of the fibonacci sequence to generate")
-	x, y int  = 0, 1
 )
 
-func Seq(iter int, x int, y int) (seq []int) {
-
+func Seq(iter int) (seq []int) {
+	// define local vars
 	var (
 		i, n int
+		x, y int = 0, 1
 	)
-
+	// initialize with seed values
 	seq = append(seq, x, y)
-
+	// iterate until length iter is reached
 	for i = 2; i < iter; i++ {
 		n = x + y
 		x = y
 		y = n
 		seq = append(seq, n)
 	}
-
-	// return a fibonacci sequence of length iter
+	// return the sequence
 	return
 }
 
@@ -34,8 +33,8 @@ func main() {
 	flag.Parse()
 
 	//get iterations
-	i := *iter
+	iter := *iter
 
 	//print the function's output
-	fmt.Println(Seq(i, x, y))
+	fmt.Println(Seq(iter))
 }

--- a/fibonacci/fibonacci_test.go
+++ b/fibonacci/fibonacci_test.go
@@ -29,7 +29,7 @@ func TestSeq(t *testing.T) {
 	fibonacci := []int{0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89}
 
 	//execute the function and report result
-	sequence := Seq(iter, 0, 1)
+	sequence := Seq(iter)
 
 	//test function generates a sequence of appropriate length and report result
 	if assert.Len(t, sequence, iter) {


### PR DESCRIPTION
Since the sequence always starts with 0 and 1, just set these as local vars.

Go doesn't allow default vars. Considered a wrapper function but it's not needed.

Adds some comments.